### PR TITLE
Scale logic fix

### DIFF
--- a/jobs/pipelines/powervs/ocp-4.9/daily-ocp4.9-powervs-toronto01-p9-scale/Jenkinsfile
+++ b/jobs/pipelines/powervs/ocp-4.9/daily-ocp4.9-powervs-toronto01-p9-scale/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
         stage('Setup Common Environment Variables') {
             steps {
                 setupCommonEnvironmentVariables()
-                setupClusterConfig("${CONFIG_TYPE}")
+                setupClusterConfig("${CONFIG_TYPE}","3")
             }
         }
         stage('pull artifact') {
@@ -146,7 +146,7 @@ pipeline {
     }
     post {
         always {
-            archiveAllArtifacts("deploy/time_taken_namespaces", "deploy/time_taken_deployments", "deploy/vars.tfvars",
+            archiveAllArtifacts("time_taken_namespaces", "time_taken_deployments", "deploy/vars.tfvars",
                 "cpu-pre.pprof", "heap-pre.pprof", "prometheus.tar.gz", "deploy/cron.log", "deploy/logs.tar.gz", "must-gather.tar.gz")
             cleanupOcp4Cluster()
             checkInfraError()

--- a/vars/setupAndRunScaleTest.groovy
+++ b/vars/setupAndRunScaleTest.groovy
@@ -8,38 +8,37 @@ def call(){
             sh 'cat ingress.yaml'
             writeFile file: 'registry.yaml', text: 'spec:\n  nodeSelector:\n    node-role.kubernetes.io/infra: ""'
             sh 'cat registry.yaml'
-            sh '''
-                cd ${WORKSPACE}/deploy
-                scp -o 'StrictHostKeyChecking no' -i id_rsa ${WORKSPACE}/ingress.yaml root@${BASTION_IP}:
-                scp -o 'StrictHostKeyChecking no' -i id_rsa ${WORKSPACE}/registry.yaml root@${BASTION_IP}:
-                ssh -o 'StrictHostKeyChecking no' -i id_rsa root@${BASTION_IP} "yum update -y;
-                yum install -y npm time;
-                npm install -g @alexlafroscia/yaml-merge;
-                git clone https://github.com/RobertKrawitz/OpenShift4-tools.git;
-                cd ~/OpenShift4-tools;
-                echo './clusterbuster -N ${SCALE_NUM_OF_NAMESPACES} -d 0 ;while [ `oc get ns | grep clusterbuster | grep -v Active | wc -l` -ne 0 ];do sleep .0000000001;done' > ./namespaces.sh;
-                chmod +x ./namespaces.sh;
-                /usr/bin/time  -o ~/time_taken_namespaces -f  'real-%E user-%U system-%S' ./namespaces.sh;
-                ./clusterbuster --cleanup;
-                sleep 60;
-                oc label node worker-0 node-role.kubernetes.io/infra="";
-                oc label node worker-1 node-role.kubernetes.io/infra="";
-                oc get nodes;
-                oc get ingresscontroller default -n openshift-ingress-operator -o yaml > base_1.yaml && yaml-merge base_1.yaml ~/ingress.yaml | kubectl apply -f - ;
-                oc get pod -n openshift-ingress -o wide;
+            sh '''#!/bin/bash
+                cd ${WORKSPACE}
+                apt-get update
+                apt-get install -y npm time uuid-runtime
+                npm install -g @alexlafroscia/yaml-merge
+                git clone https://github.com/RobertKrawitz/OpenShift4-tools.git
+                cd ${WORKSPACE}/OpenShift4-tools
+                echo './clusterbuster -N ${SCALE_NUM_OF_NAMESPACES} -d 0 ;while [ `oc get ns | grep clusterbuster | grep -v Active | wc -l` -ne 0 ];do sleep .0000000001;done' > ./namespaces.sh
+                chmod +x ./namespaces.sh
+                /usr/bin/time -o ${WORKSPACE}/time_taken_namespaces -f  "real-%E user-%U system-%S" ./namespaces.sh
+                ./clusterbuster --cleanup
+                sleep 60
+                for nodes in $(oc get node --selector='node-role.kubernetes.io/worker' --no-headers | grep 'worker-1\\|worker-2' | awk '{print $1}'); do oc label node $nodes node-role.kubernetes.io/infra=""; done
+                oc get nodes
+                oc get ingresscontroller default -n openshift-ingress-operator -o yaml > base_1.yaml && yaml-merge base_1.yaml ~/ingress.yaml | kubectl apply -f -
+                oc get pod -n openshift-ingress -o wide
                 sleep 600;
-                oc get pod -n openshift-ingress -o wide;
-                oc get configs.imageregistry.operator.openshift.io cluster -o yaml > base_2.yaml && yaml-merge base_2.yaml ~/registry.yaml | kubectl apply -f - ;
-                oc get pods -o wide -n openshift-image-registry ;
-                sleep 900 ;
-                oc get pods -o wide -n openshift-image-registry ;
-                echo './clusterbuster -d ${SCALE_NUM_OF_DEPLOYMENTS} -B ltccci ;while [ `oc get pods -n ltccci-0 | grep -v NAME | grep -v Running | wc -l` -ne 0 ];do sleep .0000000001;done' > deployments.sh;
-                chmod +x deployments.sh ;
-                /usr/bin/time -o ~/time_taken_deployments -f  'real-%E user-%U system-%S'  sh deployments.sh ;
-                ./clusterbuster --cleanup -B ltccci ;
-                oc get nodes ;
-                echo 'Get the Cluster Operators' ;
-                oc get co "
+                oc get pod -n openshift-ingress -o wide
+                oc get configs.imageregistry.operator.openshift.io cluster -o yaml > base_2.yaml && yaml-merge base_2.yaml ~/registry.yaml | kubectl apply -f -
+                oc get pods -o wide -n openshift-image-registry
+                sleep 900
+                oc get pods -o wide -n openshift-image-registry
+                for nodes in $(oc get node --selector='node-role.kubernetes.io/worker' --no-headers | grep 'worker-1\\|worker-2' | awk '{print $1}'); do oc adm cordon $nodes; done
+                echo './clusterbuster -d ${SCALE_NUM_OF_DEPLOYMENTS} -B ltccci ;while [ `oc get pods -n ltccci-0 | grep -v NAME | grep -v Running | wc -l` -ne 0 ];do sleep .0000000001;done' > deployments.sh
+                chmod +x deployments.sh
+                /usr/bin/time -o ${WORKSPACE}/time_taken_deployments -f  'real-%E user-%U system-%S'  sh deployments.sh
+                ./clusterbuster --cleanup -B ltccci
+                for nodes in $(oc get node --selector='node-role.kubernetes.io/worker' --no-headers | grep 'worker-1\\|worker-2' | awk '{print $1}'); do oc adm uncordon $nodes; done
+                oc get nodes
+                echo 'Get the Cluster Operators'
+                oc get co
             '''
         }
         catch (err) {


### PR DESCRIPTION
Updates

Labelling 2/3 worker nodes as infra nodes
Cordoning 2/3 workers before start of scale test
Uncordoning 2/3 workers after test completes.
Changes required as currently no/all worker nodes are getting labelled as infra nodes which is not achieving the purpose.

Change the test to run from jenkins pod instead of bastion
