### PR TITLE
increase ipi 4.12 jobs in syd05 and lon06 to 4x daily

### DIFF
--- a/hack/jjb_template.jinja2
+++ b/hack/jjb_template.jinja2
@@ -12,8 +12,8 @@
         {% elif 'daily-ipi4.11-powervs-london06' in JOB_NAME %}"0 00 * * * "
         {% elif 'daily-ipi4.11-powervs-osaka21' in JOB_NAME %}"0 03 * * * "
         {% elif 'daily-ipi4.12-powervs-montreal01' in JOB_NAME %}"0 */6 * * * "
-        {% elif 'daily-ipi4.12-powervs-sydney05' in JOB_NAME %}"0 08 * * * "
-        {% elif 'daily-ipi4.12-powervs-london06' in JOB_NAME %}"0 04 * * * "
+        {% elif 'daily-ipi4.12-powervs-sydney05' in JOB_NAME %}"0 */6 * * * "
+        {% elif 'daily-ipi4.12-powervs-london06' in JOB_NAME %}"0 */6 * * * "
 
         {% elif 'daily-ocp4.6-powervs-script-montreal01-p9-min' in JOB_NAME %}"0 00 * * * "
         {% elif 'daily-ocp4.7-powervs-script-montreal01-p9-min' in JOB_NAME %}"0 03 * * * "


### PR DESCRIPTION
Since we're getting good results in mon01, we'd like to increase the # of runs in these two zones.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>