### PR TITLE
Install necessary plugins for dump-powervs.sh

### DIFF
--- a/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-london06/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-london06/Jenkinsfile
@@ -167,6 +167,11 @@ pipeline {
                 else
                   exit 1
                 fi
+
+                for I in infrastructure-service power-iaas cloud-internet-services cloud-object-storage dl-cli dns; do
+                   ibmcloud plugin install ${I}
+                done
+
                 ibmcloud login -a cloud.ibm.com -r ${VPCREGION} -g ${RESOURCE_GROUP} -q --apikey=${IBMCLOUD_API_KEY}
                 ./powervs-hack/scripts/dump-powervs.sh
                 retries=0

--- a/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-montreal01/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-montreal01/Jenkinsfile
@@ -166,6 +166,11 @@ pipeline {
                 else
                   exit 1
                 fi
+
+                for I in infrastructure-service power-iaas cloud-internet-services cloud-object-storage dl-cli dns; do
+                   ibmcloud plugin install ${I}
+                done
+
                 ibmcloud login -a cloud.ibm.com -r ${VPCREGION} -g ${RESOURCE_GROUP} -q --apikey=${IBMCLOUD_API_KEY}
                 ./powervs-hack/scripts/dump-powervs.sh
                 retries=0

--- a/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-osaka21/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-osaka21/Jenkinsfile
@@ -166,6 +166,11 @@ pipeline {
                 else
                   exit 1
                 fi
+
+                for I in infrastructure-service power-iaas cloud-internet-services cloud-object-storage dl-cli dns; do
+                   ibmcloud plugin install ${I}
+                done
+
                 ibmcloud login -a cloud.ibm.com -r ${VPCREGION} -g ${RESOURCE_GROUP} -q --apikey=${IBMCLOUD_API_KEY}
                 ./powervs-hack/scripts/dump-powervs.sh
                 retries=0

--- a/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-sydney05/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi-4.12/daily-ipi4.12-powervs-sydney05/Jenkinsfile
@@ -166,6 +166,11 @@ pipeline {
                 else
                   exit 1
                 fi
+
+                for I in infrastructure-service power-iaas cloud-internet-services cloud-object-storage dl-cli dns; do
+                   ibmcloud plugin install ${I}
+                done
+
                 ibmcloud login -a cloud.ibm.com -r ${VPCREGION} -g ${RESOURCE_GROUP} -q --apikey=${IBMCLOUD_API_KEY}
                 ./powervs-hack/scripts/dump-powervs.sh
                 retries=0


### PR DESCRIPTION
Currently the post-run `dump-powervs.sh` step is failing with 'dl' is not a registered command. Check your list of installed plug-ins. See 'ibmcloud help'. This should add the necessary plugins.