### PR TITLE
Updating Z stream jobs

### DIFF
--- a/jobs/pipelines/powervm/ocp/zstreams/zstream-ocp4x-p8-min-current-upgrade/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/zstreams/zstream-ocp4x-p8-min-current-upgrade/Jenkinsfile
@@ -37,15 +37,18 @@ pipeline {
         TIMEOUT = "${params.KeepFor}"
         ENABLE_E2E_TEST="true"
 
+        //Branch
+        OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"//The download branch
+
         //Env constants
         HARDWARE_CHOSE = "P8"
-        AVAILABILITY_ZONE = "zstream"
+        AVAILABILITY_ZONE = "p8_pvm"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"
+        TERRAFORM_VER = "1.2.0"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "0"
-        REDHAT_RELEASE = "8.4"
         ENABLE_SCALE_TEST="false"
     }
 
@@ -63,7 +66,6 @@ pipeline {
                     wrap([$class: 'BuildUser']) {
                         env.INSTANCE_NAME = "rdr-zscurst"
                     }
-                    env.TERRAFORM_VER = "1.2.0"
                     env.OS_TENANT_NAME="icp-test"
                     env.OS_NETWORK = "workload"
                     env.OS_PRIVATE_NETWORK = "workload"
@@ -74,15 +76,17 @@ pipeline {
                     env.UPGRADE_PAUSE_TIME = "90"
                     env.SETUP_SQUID_PROXY = "true"
                     env.E2E_EXCLUDE_LIST="https://raw.github.ibm.com/redstack-power/e2e-exclude-list/${env.UPGRADE_RELEASE}-powervm/ocp${env.UPGRADE_RELEASE}_power_exclude_list.txt"
-                    env.OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"
-                    if ( env.UPGRADE_RELEASE == "4.6"||env.UPGRADE_RELEASE == "4.7")  {
-                        env.GOLANG_TARBALL = "https://dl.google.com/go/go1.15.2.linux-ppc64le.tar.gz"
-                    }
-                    else if (env.UPGRADE_RELEASE == "4.8" || env.UPGRADE_RELEASE == "4.9"){
+                    if (env.OCP_RELEASE == "4.8" || env.OCP_RELEASE == "4.9"){
+                        env.REDHAT_RELEASE = "8.4"
                         env.GOLANG_TARBALL = "https://dl.google.com/go/go1.16.5.linux-ppc64le.tar.gz"
                     }
-                    else{
+                    else if (env.OCP_RELEASE == "4.10" || env.OCP_RELEASE == "4.11"){
+                        env.REDHAT_RELEASE = "8.5"
                         env.GOLANG_TARBALL = "https://dl.google.com/go/go1.17.6.linux-ppc64le.tar.gz"
+                    }
+                    else {
+                        env.REDHAT_RELEASE = "8.6"
+                        env.GOLANG_TARBALL = "https://golang.org/dl/go1.18.6.linux-ppc64le.tar.gz"
                     }
                 }
             }
@@ -142,15 +146,7 @@ pipeline {
                                 '''
                             }
                             else {
-                                def OCP_VERSION_PATTERN = ~/[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}/
-                                def OCP_UPGRADE_VERSION = (env.UPGRADE_BUILD =~ OCP_VERSION_PATTERN)
-                                if (env.UPGRADE_RELEASE == "4.6" && OCP_UPGRADE_VERSION.find()) {
-                                    env.UPGRADE_CHANNEL = "fast-4.6"
-                                    env.UPGRADE_VERSION = OCP_UPGRADE_VERSION[0]
-                                }
-                                else{
-                                    env.UPGRADE_IMAGE = env.UPGRADE_BUILD
-                                }
+                                env.UPGRADE_IMAGE = env.UPGRADE_BUILD
                             }
                         }
                         else{

--- a/jobs/pipelines/powervm/ocp/zstreams/zstream-ocp4x-p8-min-direct-deploy/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/zstreams/zstream-ocp4x-p8-min-direct-deploy/Jenkinsfile
@@ -35,15 +35,18 @@ pipeline {
         TIMEOUT = "${params.KeepFor}"
         ENABLE_E2E_TEST="true"
 
+        //Branch
+        OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"//The download branch
+
         //Env constants
         HARDWARE_CHOSE = "P8"
-        AVAILABILITY_ZONE = "zstream"
+        AVAILABILITY_ZONE = "p8-new"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"
+        TERRAFORM_VER = "1.2.0"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "0"
-        REDHAT_RELEASE = "8.4"
         ENABLE_SCALE_TEST="false"
     }
 
@@ -61,22 +64,23 @@ pipeline {
                     wrap([$class: 'BuildUser']) {
                         env.INSTANCE_NAME = "rdr-zstream"
                     }
-                    env.TERRAFORM_VER = "1.2.0"
                     env.OS_TENANT_NAME="icp-test"
                     env.OS_NETWORK = "workload"
                     env.OS_PRIVATE_NETWORK = "workload"
                     env.SCG_ID = "4366c1e2-bb4f-4c3d-98a2-06cc39bbc58d"
                     env.MOUNT_ETCD_RAMDISK = "false"
                     env.SETUP_SQUID_PROXY = "true"
-                    env.OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"
-                    if ( env.OCP_RELEASE == "4.6"||env.OCP_RELEASE == "4.7")  {
-                        env.GOLANG_TARBALL = "https://dl.google.com/go/go1.15.2.linux-ppc64le.tar.gz"
-                    }
-                    else if (env.OCP_RELEASE == "4.8" || env.OCP_RELEASE == "4.9"){
+                    if (env.OCP_RELEASE == "4.8" || env.OCP_RELEASE == "4.9"){
+                        env.REDHAT_RELEASE = "8.4"
                         env.GOLANG_TARBALL = "https://dl.google.com/go/go1.16.5.linux-ppc64le.tar.gz"
                     }
-                    else{
+                    else if (env.OCP_RELEASE == "4.10" || env.OCP_RELEASE == "4.11"){
+                        env.REDHAT_RELEASE = "8.5"
                         env.GOLANG_TARBALL = "https://dl.google.com/go/go1.17.6.linux-ppc64le.tar.gz"
+                    }
+                    else {
+                        env.REDHAT_RELEASE = "8.6"
+                        env.GOLANG_TARBALL = "https://golang.org/dl/go1.18.6.linux-ppc64le.tar.gz"
                     }
                 }
             }
@@ -151,7 +155,6 @@ pipeline {
                         createTemplate(env.OS_AUTH_URL, env.WORKER_VCPUS , "${WORKER_MEMORY_MB}", env.WORKER_PROCESSORS, env.WORKER_TEMPLATE)
                         createTemplate(env.OS_AUTH_URL, env.BASTION_VCPUS , "${BASTION_MEMORY_MB}", env.BASTION_PROCESSORS, env.BASTION_TEMPLATE)
                         createTemplate(env.OS_AUTH_URL, env.BOOTSTRAP_VCPUS , "${BOOTSTRAP_MEMORY_MB}", env.BOOTSTRAP_PROCESSORS, env.BOOTSTRAP_TEMPLATE)
-                        println "cluster build: ${env.OPENSHIFT_IMAGE}"
                     }
                     catch (err)
                     {

--- a/jobs/pipelines/powervm/ocp/zstreams/zstream-ocp4x-p8-min-next-upgrade/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/zstreams/zstream-ocp4x-p8-min-next-upgrade/Jenkinsfile
@@ -37,15 +37,18 @@ pipeline {
         UPGRADE_BUILD="${params.UpgradeBuild}"
         TIMEOUT = "${params.KeepFor}"
 
+        //Branch
+        OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"//The download branch
+
         //Env constants
         HARDWARE_CHOSE = "P8"
-        AVAILABILITY_ZONE = "zstream"
+        AVAILABILITY_ZONE = "p8-new"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"
+        TERRAFORM_VER = "1.2.0"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "0"
-        REDHAT_RELEASE = "8.4"
         ENABLE_SCALE_TEST="false"
     }
 
@@ -58,7 +61,6 @@ pipeline {
                     wrap([$class: 'BuildUser']) {
                         env.INSTANCE_NAME = "rdr-zsnxt"
                     }
-                   env.TERRAFORM_VER = "1.2.0"
                     env.OS_TENANT_NAME="icp-test"
                     env.OS_NETWORK = "workload"
                     env.OS_PRIVATE_NETWORK = "workload"
@@ -67,7 +69,16 @@ pipeline {
                     env.UPGRADE_DELAY_TIME = "600"
                     env.UPGRADE_PAUSE_TIME = "90"
                     env.SETUP_SQUID_PROXY = "true"
-                    env.OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"
+
+                    if (env.OCP_RELEASE == "4.8" || env.OCP_RELEASE == "4.9"){
+                        env.REDHAT_RELEASE = "8.4"
+                    }
+                    else if (env.OCP_RELEASE == "4.10" || env.OCP_RELEASE == "4.11"){
+                        env.REDHAT_RELEASE = "8.5"
+                    }
+                    else {
+                        env.REDHAT_RELEASE = "8.6"
+                    }
                 }
             }
         }
@@ -161,8 +172,6 @@ pipeline {
                         createTemplate(env.OS_AUTH_URL, env.WORKER_VCPUS , "${WORKER_MEMORY_MB}", env.WORKER_PROCESSORS, env.WORKER_TEMPLATE)
                         createTemplate(env.OS_AUTH_URL, env.BASTION_VCPUS , "${BASTION_MEMORY_MB}", env.BASTION_PROCESSORS, env.BASTION_TEMPLATE)
                         createTemplate(env.OS_AUTH_URL, env.BOOTSTRAP_VCPUS , "${BOOTSTRAP_MEMORY_MB}", env.BOOTSTRAP_PROCESSORS, env.BOOTSTRAP_TEMPLATE)
-                        println "cluster current build: ${env.OPENSHIFT_IMAGE}" 
-                        println "cluster upgrade build: ${env.UPGRADE_IMAGE}"
                     }
                     catch (err)
                     {

--- a/jobs/pipelines/powervm/ocp/zstreams/zstream-powervm-trigger-job/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/zstreams/zstream-powervm-trigger-job/Jenkinsfile
@@ -65,14 +65,14 @@ def getChangedFilesList() {
         then
             mkdir  "versions"
         fi
-        for x in 6 7 8
+        for x in 8 9 10 11 12
         do
-            VERSION=`curl -X GET "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?onlyActiveTags=true&limit=100" | jq '.tags | sort_by(.start_ts) | .[].name'  | grep 4.$x | grep "ppc64le"  | grep -v multi | grep -v fc | grep -v rc | tail -1 |  tr -d '"'`
+            VERSION=`curl -X GET "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?onlyActiveTags=true&limit=100" | jq '.tags | sort_by(.start_ts) | .[].name' | grep "4.${x}.*ppc64le" | grep -v "multi\\|rc\\|ec\\|fc" | tail -1 | tr -d '"'`
             if [ "$VERSION" = "" ] && [ ! -f versions/4.$x.txt ];
             then
                 for i in 2 3 4 5 6 7 8 9 10 11 12
                 do
-                    VERSION=`curl -X GET "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?onlyActiveTags=true&limit=100&page=$i" | jq '.tags | sort_by(.start_ts) | .[].name'  | grep 4.$x | grep "ppc64le"  | grep -v multi | grep -v fc | grep -v rc | tail -1 |  tr -d '"'`
+                    VERSION=`curl -X GET "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?onlyActiveTags=true&limit=100&page=$i" | jq '.tags | sort_by(.start_ts) | .[].name' | grep "4.${x}.*ppc64le" | grep -v "multi\\|rc\\|ec\\|fc" | tail -1 | tr -d '"'`
                     if [ "$VERSION" != "" ] ;
                     then
                         break


### PR DESCRIPTION
This PR includes:
- Adding support for OCP 4.12 release
- Removing trigger for OCP 4.6 and 4.7 releases
- Changing host group for PowerVC jobs

Signed-off-by: Varad Ahirwadkar <varad.ahirwadkar@ibm.com>