### PR TITLE
Create Pipelines in PowerVC for 4.13

### DIFF
--- a/hack/jjb_template.jinja2
+++ b/hack/jjb_template.jinja2
@@ -43,14 +43,14 @@
 
         {% elif 'daily-ocp4.10-powervm-p9-min' in JOB_NAME %}" "
         {% elif 'daily-ocp4.11-powervm-p9-min' in JOB_NAME %}"  "
-        {% elif 'daily-ocp4.12-powervm-p9-sriov' in JOB_NAME %}"00 05 * * 1 "
+        {% elif 'daily-ocp4.13-powervm-p9-sriov' in JOB_NAME %}"00 05 * * 1 "
         {% elif 'daily-ocp4.12-powervm-p9-ssp' in JOB_NAME %}" "
         {% elif 'daily-odf4.12-powervm-p9-tier-4b' in JOB_NAME %}"00 06 * * 1,3,5,7 "
         {% elif 'daily-odf4.12-powervm-p9-tier-3' in JOB_NAME %}"00 06 * * 2,4,6 "
 
         {% elif 'daily-ocp4.10-powervm-p10-min' in JOB_NAME %}" "
-        {% elif 'daily-ocp4.12-powervm-p10-sdn-min' in JOB_NAME %}"00 07 * * 4 "
-        {% elif 'daily-ocp4.12-powervm-p10-vscsi' in JOB_NAME %}"00 07 * * 3  "
+        {% elif 'daily-ocp4.13-powervm-p10-sdn-min' in JOB_NAME %}"00 07 * * 4 "
+        {% elif 'daily-ocp4.13-powervm-p10-vscsi' in JOB_NAME %}"00 07 * * 3 "
         {% elif 'daily-odf4.12-powervm-p10-tier-1' in JOB_NAME %}"00 08 * * 1,3,5,7 "
         {% elif 'daily-odf4.12-powervm-p10-tier-2' in JOB_NAME %}"00 08 * * 2,4,6 "
         {% elif 'daily-odf4.12-powervm-p10-tier-4c' in JOB_NAME %}"00 10 * * 2,4,6 "

--- a/jobs/pipelines/mirror-openshift-release/Jenkinsfile
+++ b/jobs/pipelines/mirror-openshift-release/Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
                     grep '4\\.10\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.10-builds.txt
                     grep '4\\.11\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.11-builds.txt
                     grep '4\\.12\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.12-builds.txt
+                    grep '4\\.13\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.13-builds.txt
 
                     #Latest Builds
                     cat all-4.6-builds.txt|head -n 1|awk '{print $1}' >latest-4.6-build.txt
@@ -72,6 +73,7 @@ pipeline {
                     cat all-4.10-builds.txt|head -n 1|awk '{print $1}' > latest-4.10-build.txt
                     cat all-4.11-builds.txt|head -n 1|awk '{print $1}' > latest-4.11-build.txt
                     cat all-4.12-builds.txt|head -n 1|awk '{print $1}' > latest-4.12-build.txt
+                    cat all-4.13-builds.txt|head -n 1|awk '{print $1}' > latest-4.13-build.txt
 
                     #All stable Builds
                     cat all-4.6-builds.txt | grep -v 'nightly\\|-rc\\|-fc' > all-4.6-stable-builds.txt
@@ -105,8 +107,8 @@ pipeline {
         always {
             archiveAllArtifacts("builds.raw.txt", "all-builds.txt", "all-4.6-builds.txt", "all-4.7-builds.txt",
                                   "all-4.8-builds.txt","all-4.9-builds.txt","all-4.10-builds.txt","all-4.11-builds.txt",
-                                  "all-4.12-builds.txt","latest-4.6-build.txt","latest-4.7-build.txt","latest-4.8-build.txt",
-                                  "latest-4.9-build.txt","latest-4.10-build.txt","latest-4.11-build.txt","latest-4.12-build.txt",
+                                  "all-4.12-builds.txt", "all-4.13-builds.txt", "latest-4.6-build.txt","latest-4.7-build.txt","latest-4.8-build.txt",
+                                  "latest-4.9-build.txt","latest-4.10-build.txt","latest-4.11-build.txt","latest-4.12-build.txt", "latest-4.13-build.txt",
                                   "all-4.6-stable-builds.txt","all-4.7-stable-builds.txt","all-4.8-stable-builds.txt",
                                   "all-4.9-stable-builds.txt","all-4.10-stable-builds.txt","all-4.11-stable-builds.txt",
                                    "latest-4.6-stable-build.txt", "latest-4.7-stable-build.txt","latest-4.8-stable-build.txt",

--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p10-sdn-min/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p10-sdn-min/Jenkinsfile
@@ -1,0 +1,182 @@
+@Library('jenkins-upstream-library') _
+
+pipeline {
+    agent {
+        docker {
+            image 'quay.io/powercloud/inbound-agent:4.10-3.2'
+            args '-v /etc/resolv.conf:/etc/resolv.conf'
+            label 'jump-vpc-x86_64'
+        }
+    }
+    environment {
+        //users and credentials. All must be defined in Jenkins Credentials
+        GITHUB_USER = credentials('GITHUB_USER')
+        GITHUB_TOKEN = credentials('GITHUB_TOKEN')
+        OS_USERNAME = credentials('OS_USERNAME')
+        OS_PASSWORD = credentials('OS_PASSWORD')
+        DOCKER_USER = credentials('DOCKER_USER')
+        ARTIFACTORY_USER = credentials('ARTIFACTORY_USER')
+        ARTIFACTORY_TOKEN = credentials('ARTIFACTORY_TOKEN')
+        REDHAT_USERNAME = credentials('REDHAT_USERNAME')
+        REDHAT_PASSWORD = credentials('REDHAT_PASSWORD')
+        PULL_SECRET = credentials('PULL_SECRET')
+        OS_AUTH_URL=credentials('URL_SCNLCICDPOWERVC')
+
+        //Env constants
+        HARDWARE_CHOSE = "P10"
+        TERRAFORM_VER = "1.2.0"
+        AVAILABILITY_ZONE = "p10_pvm"
+        OCP_RELEASE="4.13"
+        TARGET = "deploy-openshift4-powervc"
+        TEMPLATE_FILE = ".${TARGET}.tfvars.template"
+        POWERVS = false
+        SCRIPT_DEPLOYMENT = false
+        WAIT_FOR_DEBUG = "1"
+        REDHAT_RELEASE = "8.6"
+
+        //Branch
+        OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"//The download branch
+
+        //E2e and Scale specific variables
+        ENABLE_E2E_TEST="true"
+        ENABLE_SCALE_TEST="false"
+        GOLANG_TARBALL="https://dl.google.com/go/go1.18.6.linux-ppc64le.tar.gz"
+
+        // Type of configuration
+        CONFIG_TYPE="min"
+	 }
+
+    stages {
+        stage('Clone ansible extra') {
+            steps {
+                cloneRepo("https://github.com/ocp-power-automation/ocp4-playbooks-extras", "ocp4-playbooks-extras", "*/main")
+            }
+        }
+        stage('Setup Common Environment Variables') {
+            steps {
+                setupCommonEnvironmentVariables()
+                setupClusterConfig("${CONFIG_TYPE}")
+                script {
+                    env.CNI_NETWORK_PROVIDER = "OpenshiftSDN"
+                    env.E2E_EXCLUDE_LIST = "https://raw.github.ibm.com/redstack-power/e2e-exclude-list/${env.OCP_RELEASE}-powervs/ocp${env.OCP_RELEASE}_power_exclude_list.txt"
+                }
+            }
+        }
+        stage('pull artifact') {
+            steps {
+                script {
+                    getArtifacts("mirror-openshift-release", "latest-${OCP_RELEASE}-build.txt")
+                    getArtifacts("powervm/poll-powervc-images", "cicd-rhcos-${OCP_RELEASE}.latest.txt")
+                    getArtifacts("powervm/poll-powervc-images", "cicd-rhel-${REDHAT_RELEASE}.latest.txt")
+                }
+            }
+        }
+        //Checkout the installer git repo
+        stage('Prepare Terraform Template') {
+            steps {
+                script {
+                    ansiColor('xterm') {
+                        echo ""
+                    }
+                    try
+                    {
+                        gbToMb()
+                        pullSecret()
+                        env.OPENSHIFT_IMAGE = ""
+                        if (fileExists("deploy/artifactory/latest-${OCP_RELEASE}-build.txt")) {
+                            env.OPENSHIFT_IMAGE = readFile "deploy/artifactory/latest-${OCP_RELEASE}-build.txt"
+                            env.OPENSHIFT_IMAGE = env.OPENSHIFT_IMAGE.trim()
+                            env.OCP_RELEASE_TAG = env.OPENSHIFT_IMAGE.split(":")[1].trim()
+                        }
+                        else {
+                            echo "latest-${OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            throw err
+                        }
+                        if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {
+                            env.RHCOS_IMAGE = readFile "deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt"
+                            env.RHCOS_IMAGE_NAME = env.RHCOS_IMAGE.split()[0].trim()
+                            env.RHCOS_IMAGE_ID = env.RHCOS_IMAGE.split()[1].trim()
+                        }
+                        else {
+                            echo "cicd-rhcos-${OCP_RELEASE}.latest.txt file does not exist. Please check poll-powervc-images job"
+                            throw err
+                        }
+                        if (fileExists("deploy/artifactory/cicd-rhel-${REDHAT_RELEASE}.latest.txt")) {
+                            env.BASTION_IMAGE = readFile "deploy/artifactory/cicd-rhel-${REDHAT_RELEASE}.latest.txt"
+                            env.BASTION_IMAGE_NAME = env.BASTION_IMAGE.split()[0].trim()
+                            env.BASTION_IMAGE_ID = env.BASTION_IMAGE.split()[1].trim()
+                        }
+                        else {
+                            echo "cicd-rhel-${REDHAT_RELEASE}.latest.txt file does not exist. Please check poll-powervc-images job"
+                            throw err
+                        }
+                        if (env.DEPLOY_MASTER == "false")
+                        {
+                            echo "Cluster cant deploy without master"
+                            throw err
+                        }
+
+                        createTemplate(env.OS_AUTH_URL, env.MASTER_VCPUS , "${MASTER_MEMORY_MB}", env.MASTER_PROCESSORS, env.MASTER_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.WORKER_VCPUS , "${WORKER_MEMORY_MB}", env.WORKER_PROCESSORS, env.WORKER_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.BASTION_VCPUS , "${BASTION_MEMORY_MB}", env.BASTION_PROCESSORS, env.BASTION_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.BOOTSTRAP_VCPUS , "${BOOTSTRAP_MEMORY_MB}", env.BOOTSTRAP_PROCESSORS, env.BOOTSTRAP_TEMPLATE)
+                    }
+                    catch (err)
+                    {
+                        echo 'Error ! Template preparation failed !'
+                        env.FAILED_STAGE=env.STAGE_NAME
+                        throw err
+                    }
+                }
+            }
+        }
+        stage('Initialize Environment') {
+            steps {
+                initializeEnvironment()
+            }
+        }
+        stage('Setup Terraform Plugin') {
+            steps {
+                setupTerraformPlugin()
+            }
+        }
+        stage('Deploy OCP Cluster') {
+            steps {
+                deployCluster()
+            }
+        }
+        stage('Run crontab script for capturing outputs of multiple commands') {
+            steps {
+                crontabCommandCaptureScript()
+            }
+        }
+        stage('Setup Kubectl') {
+            steps {
+                setupKubeconfigOcp4()
+            }
+        }
+        stage('Setup and run ansible extra') {
+            steps {
+               setupAndRunE2e()
+            }
+        }
+        stage('Gather pprof and prometheus data') {
+            steps {
+                //gatherPrometheusData()
+                echo "gatherPrometheusData() is skipped for now"
+            }
+        }
+    }
+    post {
+        always {
+            archiveAllArtifacts("deploy/conformance-parallel-out.txt.tar.gz", "deploy/summary.txt", "deploy/vars.tfvars",
+                "cpu-pre.pprof", "heap-pre.pprof", "prometheus.tar.gz", "deploy/cron.log", "must-gather.tar.gz")
+            cleanupOcp4Cluster()
+            checkInfraError()
+            processE2eResults()
+            dbDashboardUpdateE2e()
+            notifyBySlack(currentBuild.result, env.MESSAGE)
+            cleanWs()
+        }
+    }
+}

--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p10-vscsi/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p10-vscsi/Jenkinsfile
@@ -1,0 +1,181 @@
+@Library('jenkins-upstream-library') _
+
+pipeline {
+    agent {
+        docker {
+            image 'quay.io/powercloud/inbound-agent:4.10-3.2'
+            args '-v /etc/resolv.conf:/etc/resolv.conf'
+            label 'jump-vpc-x86_64'
+        }
+    }
+    environment {
+        //users and credentials. All must be defined in Jenkins Credentials
+        GITHUB_USER = credentials('GITHUB_USER')
+        GITHUB_TOKEN = credentials('GITHUB_TOKEN')
+        OS_USERNAME = credentials('OS_USERNAME')
+        OS_PASSWORD = credentials('OS_PASSWORD')
+        DOCKER_USER = credentials('DOCKER_USER')
+        ARTIFACTORY_USER = credentials('ARTIFACTORY_USER')
+        ARTIFACTORY_TOKEN = credentials('ARTIFACTORY_TOKEN')
+        REDHAT_USERNAME = credentials('REDHAT_USERNAME')
+        REDHAT_PASSWORD = credentials('REDHAT_PASSWORD')
+        PULL_SECRET = credentials('PULL_SECRET')
+        OS_AUTH_URL=credentials('URL_SCNLCICDPOWERVC')
+
+        //Env constants
+        HARDWARE_CHOSE = "P10"
+        TERRAFORM_VER = "1.2.0"
+        AVAILABILITY_ZONE = "p10_pvm"
+        OCP_RELEASE="4.13"
+        TARGET = "deploy-openshift4-powervc"
+        TEMPLATE_FILE = ".${TARGET}.tfvars.template"
+        POWERVS = false
+        SCRIPT_DEPLOYMENT = false
+        WAIT_FOR_DEBUG = "1"
+        REDHAT_RELEASE = "8.6"
+
+        //Branch
+        OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"//The download branch
+
+        //E2e and Scale specific variables
+        ENABLE_E2E_TEST="true"
+        ENABLE_SCALE_TEST="false"
+        GOLANG_TARBALL="https://dl.google.com/go/go1.18.6.linux-ppc64le.tar.gz"
+
+        // Type of configuration
+         CONFIG_TYPE="min"
+	 }
+
+    stages {
+        stage('Clone ansible extra') {
+            steps {
+                cloneRepo("https://github.com/ocp-power-automation/ocp4-playbooks-extras", "ocp4-playbooks-extras", "*/main")
+            }
+        }
+        stage('Setup Common Environment Variables') {
+            steps {
+                setupCommonEnvironmentVariables()
+                setupClusterConfig("${CONFIG_TYPE}")
+                script {
+                    env.SCG_ID = "8a5ff38d-0e88-40bd-8bc3-2d1434789461"
+                }
+            }
+        }
+        stage('pull artifact') {
+            steps {
+                script {
+                    getArtifacts("mirror-openshift-release", "latest-${OCP_RELEASE}-build.txt")
+                    getArtifacts("powervm/poll-powervc-images", "cicd-rhcos-${OCP_RELEASE}.latest.txt")
+                    getArtifacts("powervm/poll-powervc-images", "cicd-rhel-${REDHAT_RELEASE}.latest.txt")
+                }
+            }
+        }
+        //Checkout the installer git repo
+        stage('Prepare Terraform Template') {
+            steps {
+                script {
+                    ansiColor('xterm') {
+                        echo ""
+                    }
+                    try
+                    {
+                        gbToMb()
+                        pullSecret()
+                        env.OPENSHIFT_IMAGE = ""
+                        if (fileExists("deploy/artifactory/latest-${OCP_RELEASE}-build.txt")) {
+                            env.OPENSHIFT_IMAGE = readFile "deploy/artifactory/latest-${OCP_RELEASE}-build.txt"
+                            env.OPENSHIFT_IMAGE = env.OPENSHIFT_IMAGE.trim()
+                            env.OCP_RELEASE_TAG = env.OPENSHIFT_IMAGE.split(":")[1].trim()
+                        }
+                        else {
+                            echo "latest-${OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            throw err
+                        }
+                        if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {
+                            env.RHCOS_IMAGE = readFile "deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt"
+                            env.RHCOS_IMAGE_NAME = env.RHCOS_IMAGE.split()[0].trim()
+                            env.RHCOS_IMAGE_ID = env.RHCOS_IMAGE.split()[1].trim()
+                        }
+                        else {
+                            echo "cicd-rhcos-${OCP_RELEASE}.latest.txt file does not exist. Please check poll-powervc-images job"
+                            throw err
+                        }
+                        if (fileExists("deploy/artifactory/cicd-rhel-${REDHAT_RELEASE}.latest.txt")) {
+                            env.BASTION_IMAGE = readFile "deploy/artifactory/cicd-rhel-${REDHAT_RELEASE}.latest.txt"
+                            env.BASTION_IMAGE_NAME = env.BASTION_IMAGE.split()[0].trim()
+                            env.BASTION_IMAGE_ID = env.BASTION_IMAGE.split()[1].trim()
+                        }
+                        else {
+                            echo "cicd-rhel-${REDHAT_RELEASE}.latest.txt file does not exist. Please check poll-powervc-images job"
+                            throw err
+                        }
+                        if (env.DEPLOY_MASTER == "false")
+                        {
+                            echo "Cluster cant deploy without master"
+                            throw err
+                        }
+
+                        createTemplate(env.OS_AUTH_URL, env.MASTER_VCPUS , "${MASTER_MEMORY_MB}", env.MASTER_PROCESSORS, env.MASTER_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.WORKER_VCPUS , "${WORKER_MEMORY_MB}", env.WORKER_PROCESSORS, env.WORKER_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.BASTION_VCPUS , "${BASTION_MEMORY_MB}", env.BASTION_PROCESSORS, env.BASTION_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.BOOTSTRAP_VCPUS , "${BOOTSTRAP_MEMORY_MB}", env.BOOTSTRAP_PROCESSORS, env.BOOTSTRAP_TEMPLATE)
+                    }
+                    catch (err)
+                    {
+                        echo 'Error ! Template preparation failed !'
+                        env.FAILED_STAGE=env.STAGE_NAME
+                        throw err
+                    }
+                }
+            }
+        }
+        stage('Initialize Environment') {
+            steps {
+                initializeEnvironment()
+            }
+        }
+        stage('Setup Terraform Plugin') {
+            steps {
+                setupTerraformPlugin()
+            }
+        }
+        stage('Deploy OCP Cluster') {
+            steps {
+                deployCluster()
+            }
+        }
+        stage('Run crontab script for capturing outputs of multiple commands') {
+            steps {
+                crontabCommandCaptureScript()
+            }
+        }
+        stage('Setup Kubectl') {
+            steps {
+                setupKubeconfigOcp4()
+            }
+        }
+        stage('Setup and run ansible extra') {
+            steps {
+               setupAndRunE2e()
+            }
+        }
+        stage('Gather pprof and prometheus data') {
+            steps {
+                //gatherPrometheusData()
+                echo "gatherPrometheusData() is skipped for now"
+            }
+        }
+    }
+    post {
+        always {
+            archiveAllArtifacts("deploy/conformance-parallel-out.txt.tar.gz", "deploy/summary.txt", "deploy/vars.tfvars",
+                "cpu-pre.pprof", "heap-pre.pprof", "prometheus.tar.gz", "deploy/cron.log", "must-gather.tar.gz")
+            cleanupOcp4Cluster()
+            checkInfraError()
+            processE2eResults()
+            dbDashboardUpdateE2e()
+            notifyBySlack(currentBuild.result, env.MESSAGE)
+            cleanWs()
+        }
+    }
+}

--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-sriov/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-sriov/Jenkinsfile
@@ -1,0 +1,186 @@
+@Library('jenkins-upstream-library') _
+
+pipeline {
+    agent {
+        docker {
+            image 'quay.io/powercloud/inbound-agent:4.10-3.2'
+            args '-v /etc/resolv.conf:/etc/resolv.conf'
+            label 'jump-vpc-x86_64'
+        }
+    }
+    environment {
+        //users and credentials. All must be defined in Jenkins Credentials
+        GITHUB_USER = credentials('GITHUB_USER')
+        GITHUB_TOKEN = credentials('GITHUB_TOKEN')
+        OS_USERNAME = credentials('OS_USERNAME')
+        OS_PASSWORD = credentials('OS_PASSWORD')
+        DOCKER_USER = credentials('DOCKER_USER')
+        ARTIFACTORY_USER = credentials('ARTIFACTORY_USER')
+        ARTIFACTORY_TOKEN = credentials('ARTIFACTORY_TOKEN')
+        REDHAT_USERNAME = credentials('REDHAT_USERNAME')
+        REDHAT_PASSWORD = credentials('REDHAT_PASSWORD')
+        PULL_SECRET = credentials('PULL_SECRET')
+        OS_AUTH_URL=credentials('URL_SCNLCICDPOWERVC')
+
+        //Env constants
+        HARDWARE_CHOSE = "P9"
+        TERRAFORM_VER = "1.2.0"
+        AVAILABILITY_ZONE = "p9_pvm"
+        OCP_RELEASE="4.13"
+        TARGET = "deploy-openshift4-powervc"
+        TEMPLATE_FILE = ".${TARGET}.tfvars.template"
+        POWERVS = false
+        SCRIPT_DEPLOYMENT = false
+        WAIT_FOR_DEBUG = "1"
+        REDHAT_RELEASE = "8.6"
+
+        //Branch
+        OPENSHIFT_POWERVC_GIT_TF_DEPLOY_BRANCH="main"//The download branch
+
+        //E2e and Scale specific variables
+        ENABLE_E2E_TEST="true"
+        ENABLE_SCALE_TEST="false"
+        GOLANG_TARBALL="https://dl.google.com/go/go1.18.6.linux-ppc64le.tar.gz"
+
+        // Type of configuration
+        CONFIG_TYPE="min"
+	 }
+
+    stages {
+        stage('Clone ansible extra') {
+            steps {
+                cloneRepo("https://github.com/ocp-power-automation/ocp4-playbooks-extras", "ocp4-playbooks-extras", "*/main")
+            }
+        }
+        stage('Setup Common Environment Variables') {
+            steps {
+                setupCommonEnvironmentVariables()
+                setupClusterConfig("${CONFIG_TYPE}")
+                script {
+                    //Set SRIOV network
+                    env.NETWORK_TYPE = "SRIOV"
+                    env.OS_NETWORK = "icp_network2"
+                    env.OS_PRIVATE_NETWORK = "icp_network2"
+                    //Issue-2277 Remove scg id when npiv issue is resolved
+                    env.SCG_ID = "8a5ff38d-0e88-40bd-8bc3-2d1434789461"
+                }
+            }
+        }
+        stage('pull artifact') {
+            steps {
+                script {
+                    getArtifacts("mirror-openshift-release", "latest-${OCP_RELEASE}-build.txt")
+                    getArtifacts("powervm/poll-powervc-images", "cicd-rhcos-${OCP_RELEASE}.latest.txt")
+                    getArtifacts("powervm/poll-powervc-images", "cicd-rhel-${REDHAT_RELEASE}.latest.txt")
+                }
+            }
+        }
+        //Checkout the installer git repo
+        stage('Prepare Terraform Template') {
+            steps {
+                script {
+                    ansiColor('xterm') {
+                        echo ""
+                    }
+                    try
+                    {
+                        gbToMb()
+                        pullSecret()
+                        env.OPENSHIFT_IMAGE = ""
+                        if (fileExists("deploy/artifactory/latest-${OCP_RELEASE}-build.txt")) {
+                            env.OPENSHIFT_IMAGE = readFile "deploy/artifactory/latest-${OCP_RELEASE}-build.txt"
+                            env.OPENSHIFT_IMAGE = env.OPENSHIFT_IMAGE.trim()
+                            env.OCP_RELEASE_TAG = env.OPENSHIFT_IMAGE.split(":")[1].trim()
+                        }
+                        else {
+                            echo "latest-${OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            throw err
+                        }
+                        if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {
+                            env.RHCOS_IMAGE = readFile "deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt"
+                            env.RHCOS_IMAGE_NAME = env.RHCOS_IMAGE.split()[0].trim()
+                            env.RHCOS_IMAGE_ID = env.RHCOS_IMAGE.split()[1].trim()
+                        }
+                        else {
+                            echo "cicd-rhcos-${OCP_RELEASE}.latest.txt file does not exist. Please check poll-powervc-images job"
+                            throw err
+                        }
+                        if (fileExists("deploy/artifactory/cicd-rhel-${REDHAT_RELEASE}.latest.txt")) {
+                            env.BASTION_IMAGE = readFile "deploy/artifactory/cicd-rhel-${REDHAT_RELEASE}.latest.txt"
+                            env.BASTION_IMAGE_NAME = env.BASTION_IMAGE.split()[0].trim()
+                            env.BASTION_IMAGE_ID = env.BASTION_IMAGE.split()[1].trim()
+                        }
+                        else {
+                            echo "cicd-rhel-${REDHAT_RELEASE}.latest.txt file does not exist. Please check poll-powervc-images job"
+                            throw err
+                        }
+                        if (env.DEPLOY_MASTER == "false")
+                        {
+                            echo "Cluster cant deploy without master"
+                            throw err
+                        }
+
+                        createTemplate(env.OS_AUTH_URL, env.MASTER_VCPUS , "${MASTER_MEMORY_MB}", env.MASTER_PROCESSORS, env.MASTER_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.WORKER_VCPUS , "${WORKER_MEMORY_MB}", env.WORKER_PROCESSORS, env.WORKER_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.BASTION_VCPUS , "${BASTION_MEMORY_MB}", env.BASTION_PROCESSORS, env.BASTION_TEMPLATE)
+                        createTemplate(env.OS_AUTH_URL, env.BOOTSTRAP_VCPUS , "${BOOTSTRAP_MEMORY_MB}", env.BOOTSTRAP_PROCESSORS, env.BOOTSTRAP_TEMPLATE)
+                    }
+                    catch (err)
+                    {
+                        echo 'Error ! Template preparation failed !'
+                        env.FAILED_STAGE=env.STAGE_NAME
+                        throw err
+                    }
+                }
+            }
+        }
+        stage('Initialize Environment') {
+            steps {
+                initializeEnvironment()
+            }
+        }
+        stage('Setup Terraform Plugin') {
+            steps {
+                setupTerraformPlugin()
+            }
+        }
+        stage('Deploy OCP Cluster') {
+            steps {
+                deployCluster()
+            }
+        }
+        stage('Run crontab script for capturing outputs of multiple commands') {
+            steps {
+                crontabCommandCaptureScript()
+            }
+        }
+        stage('Setup Kubectl') {
+            steps {
+                setupKubeconfigOcp4()
+            }
+        }
+        stage('Setup and run ansible extra') {
+            steps {
+               setupAndRunE2e()
+            }
+        }
+        stage('Gather pprof and prometheus data') {
+            steps {
+                //gatherPrometheusData()
+                echo "gatherPrometheusData() is skipped for now"
+            }
+        }
+    }
+    post {
+        always {
+            archiveAllArtifacts("deploy/conformance-parallel-out.txt.tar.gz", "deploy/summary.txt", "deploy/vars.tfvars",
+                "cpu-pre.pprof", "heap-pre.pprof", "prometheus.tar.gz", "deploy/cron.log", "must-gather.tar.gz")
+            cleanupOcp4Cluster()
+            checkInfraError()
+            processE2eResults()
+            dbDashboardUpdateE2e()
+            notifyBySlack(currentBuild.result, env.MESSAGE)
+            cleanWs()
+        }
+    }
+}

--- a/jobs/pipelines/powervm/poll-powervc-images/Jenkinsfile
+++ b/jobs/pipelines/powervm/poll-powervc-images/Jenkinsfile
@@ -59,11 +59,14 @@ pipeline {
                     cat images.scnlpowercloud.all.date.sorted.txt | grep 'cicd-rhcos-4\\.10\\|cicd-rhcos-410' | awk '{print $2" "$1}'|head -n 1 > rhcos-4.10-powercloud-latest.txt || true
                     cat images.scnlpowercloud.all.date.sorted.txt | grep 'cicd-rhcos-4\\.11\\|cicd-rhcos-411' | awk '{print $2" "$1}'|head -n 1 > rhcos-4.11-powercloud-latest.txt || true
                     cat images.scnlpowercloud.all.date.sorted.txt | grep 'cicd-rhcos-4\\.12\\|cicd-rhcos-412' | awk '{print $2" "$1}'|head -n 1 > rhcos-4.12-powercloud-latest.txt || true
+                    cat images.scnlpowercloud.all.date.sorted.txt | grep 'cicd-rhcos-4\\.13\\|cicd-rhcos-413' | awk '{print $2" "$1}'|head -n 1 > rhcos-4.13-powercloud-latest.txt || true
 
                     cat images.scnlpowercloud.all.date.sorted.txt | grep 'rhel8\\.3'  | awk '{print $2" "$1}'|head -n 1 > rhel-8.3-powercloud-latest.txt || true
                     cat images.scnlpowercloud.all.date.sorted.txt | grep 'rhel8\\.4'  | awk '{print $2" "$1}'|head -n 1 > rhel-8.4-powercloud-latest.txt || true
                     cat images.scnlpowercloud.all.date.sorted.txt | grep 'rhel8\\.5'  | awk '{print $2" "$1}'|head -n 1 > rhel-8.5-powercloud-latest.txt || true
                     cat images.scnlpowercloud.all.date.sorted.txt | grep 'rhel8\\.6'  | awk '{print $2" "$1}'|head -n 1 > rhel-8.6-powercloud-latest.txt || true
+                    cat images.scnlpowercloud.all.date.sorted.txt | grep 'rhel9\\.0'  | awk '{print $2" "$1}'|head -n 1 > rhel-9.0-powercloud-latest.txt || true
+
                     '''
                     env.OS_AUTH_URL = env.URL_SCNLCICDPOWERVC
                     sh '''
@@ -77,11 +80,13 @@ pipeline {
                     cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'cicd-rhcos-4\\.10\\|cicd-rhcos-410' | awk '{print $2" "$1}'|head -n 1 > cicd-rhcos-4.10.latest.txt || true
                     cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'cicd-rhcos-4\\.11\\|cicd-rhcos-411' | awk '{print $2" "$1}'|head -n 1 > cicd-rhcos-4.11.latest.txt || true
                     cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'cicd-rhcos-4\\.12\\|cicd-rhcos-412' | awk '{print $2" "$1}'|head -n 1 > cicd-rhcos-4.12.latest.txt || true
+                    cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'cicd-rhcos-4\\.13\\|cicd-rhcos-413' | awk '{print $2" "$1}'|head -n 1 > cicd-rhcos-4.13.latest.txt || true
 
                     cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'rhel8\\.3'  | awk '{print $2" "$1}'|head -n 1 > cicd-rhel-8.3.latest.txt || true
                     cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'rhel8\\.4'  | awk '{print $2" "$1}'|head -n 1 > cicd-rhel-8.4.latest.txt || true
                     cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'rhel8\\.5'  | awk '{print $2" "$1}'|head -n 1 > cicd-rhel-8.5.latest.txt || true
                     cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'rhel8\\.6'  | awk '{print $2" "$1}'|head -n 1 > cicd-rhel-8.6.latest.txt || true
+                    cat images.scnlcicdcloud.all.date.sorted.txt | grep -v ssp | grep 'rhel9\\.0'  | awk '{print $2" "$1}'|head -n 1 > cicd-rhel-9.0.latest.txt || true
                     '''
                     }
                     catch (err)
@@ -98,14 +103,17 @@ pipeline {
             archiveAllArtifacts("rhcos-4.6-powercloud-latest.txt", "rhcos-4.7-powercloud-latest.txt",
                                 "rhcos-4.8-powercloud-latest.txt", "rhcos-4.9-powercloud-latest.txt",
                                 "rhcos-4.10-powercloud-latest.txt", "rhcos-4.11-powercloud-latest.txt",
-                                "rhcos-4.12-powercloud-latest.txt", "rhel-8.3-powercloud-latest.txt", "rhel-8.4-powercloud-latest.txt",
+                                "rhcos-4.12-powercloud-latest.txt", "rhcos-4.13-powercloud-latest.txt",
+                                "rhel-8.3-powercloud-latest.txt", "rhel-8.4-powercloud-latest.txt",
                                 "rhel-8.5-powercloud-latest.txt", "rhel-8.6-powercloud-latest.txt",
+                                "rhel-9.0-powercloud-latest.txt",
                                 "cicd-rhcos-4.6.latest.txt", "cicd-rhcos-4.7.latest.txt",
                                 "cicd-rhcos-4.8.latest.txt", "cicd-rhcos-4.9.latest.txt",
-                                "cicd-rhcos-4.10.latest.txt", "cicd-rhcos-4.11.latest.txt", "cicd-rhcos-4.12.latest.txt",
+                                "cicd-rhcos-4.10.latest.txt", "cicd-rhcos-4.11.latest.txt",
+                                "cicd-rhcos-4.12.latest.txt", "cicd-rhcos-4.13.latest.txt",
                                 "cicd-rhel-8.2.latest.txt", "cicd-rhel-8.3.latest.txt",
                                 "cicd-rhel-8.4.latest.txt", "cicd-rhel-8.5.latest.txt" ,
-                                "cicd-rhel-8.6.latest.txt")
+                                "cicd-rhel-8.6.latest.txt", "cicd-rhel-9.0.latest.txt")
             cleanWs()
         }
     }


### PR DESCRIPTION
This PR adds the following changes to support 4.13 for PowerVC,
1. Updates Mirror job
2. Updates job poll-powervc-images to use rhel 9.0 and 4.13.
3. Creates job daily-ocp4.13-powervm-p10-sdn-min, daily-ocp4.13-powervm-p9-sriov, daily-ocp4.13-powervm-p10-vscsi and schedules them.
4. Removes schedule and jobs daily-ocp4.12-powervm-p9-sriov, daily-ocp4.12-powervm-p10-sdn-min, daily-ocp4.12-powervm-p10-vscsi.

Tested changes on Jenkins test server.
