### PR TITLE
change p9 availability zone to p9_ocp and p9_odf

### DIFF
--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-min/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-min/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9"
+        AVAILABILITY_ZONE = "p9_ocp"
         OCP_RELEASE="4.13"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"

--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-sdn-min/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-sdn-min/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9"
+        AVAILABILITY_ZONE = "p9_ocp"
         OCP_RELEASE="4.13"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"

--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-sriov/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-sriov/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9"
+        AVAILABILITY_ZONE = "p9_ocp"
         OCP_RELEASE="4.13"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"

--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-verification/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-verification/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9"
+        AVAILABILITY_ZONE = "p9_ocp"
         OCP_RELEASE="4.13"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"

--- a/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-vscsi/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/daily-ocp4.13-powervm-p9-vscsi/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9"
+        AVAILABILITY_ZONE = "p9_ocp"
         OCP_RELEASE="4.13"
         TARGET = "deploy-openshift4-powervc"
         TEMPLATE_FILE = ".${TARGET}.tfvars.template"

--- a/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-1/Jenkinsfile
+++ b/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-1/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9_pvm"
+        AVAILABILITY_ZONE = "p9_odf"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "1"

--- a/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-2/Jenkinsfile
+++ b/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-2/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9_pvm"
+        AVAILABILITY_ZONE = "p9_odf"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "1"

--- a/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-3/Jenkinsfile
+++ b/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-3/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9_pvm"
+        AVAILABILITY_ZONE = "p9_odf"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "1"

--- a/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-4b/Jenkinsfile
+++ b/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-4b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9_pvm"
+        AVAILABILITY_ZONE = "p9_odf"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "1"

--- a/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-4c/Jenkinsfile
+++ b/jobs/pipelines/powervm/odf/4.12/daily-odf4.12-powervm-p9-tier-4c/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         //Env constants
         HARDWARE_CHOSE = "P9"
         TERRAFORM_VER = "1.2.0"
-        AVAILABILITY_ZONE = "p9_pvm"
+        AVAILABILITY_ZONE = "p9_odf"
         POWERVS = false
         SCRIPT_DEPLOYMENT = false
         WAIT_FOR_DEBUG = "1"


### PR DESCRIPTION
This PR changes p9 availability zone to p9_ocp and p9_odf for currently running ocp and odf pipelines respectively
Signed-off-by: Neha Yadav <neha.yadav3@ibm.com>