### PR TITLE
updated go version from 1.18 to 1.19 in hypershift job

### DIFF
--- a/jobs/pipelines/powervs/hypershift/daily-ocp4.12-powervs-sydney04-hypershift-e2e/Jenkinsfile
+++ b/jobs/pipelines/powervs/hypershift/daily-ocp4.12-powervs-sydney04-hypershift-e2e/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         PULL_SECRET_FILE="${WORKSPACE}/pull_secret.txt"
         PULL_SECRET="${PULL_SECRET_FILE}"
         DUMP_DIR="${WORKSPACE}/hypershift-e2e"
-        GO_VERSION="1.18"
+        GO_VERSION="1.19"
     }
 
     stages {


### PR DESCRIPTION
Updated `GO_VERSION="1.19"` in` jobs/pipelines/powervs/hypershift/daily-ocp4.12-powervs-sydney04-hypershift-e2e/Jenkinsfile`