### PR TITLE
Do not run nodes_config playbook

### DIFF
--- a/deploy/templates/.deploy-openshift4-powervc.tfvars.template
+++ b/deploy/templates/.deploy-openshift4-powervc.tfvars.template
@@ -80,6 +80,7 @@ upgrade_pause_time = "__UPGRADE_PAUSE_TIME__"
 upgrade_delay_time = "__UPGRADE_DELAY_TIME__"
 
 chrony_config = "__CHRONY_CONFIG__"
+install_playbook_repo = "__INSTALL_PLAYBOOK_REPO__"
 
 ocp4_extras_playbook_tag = "335a0dc1b329c3f05e3b48409441d9eb1420c27b"
 

--- a/deploy/templates/.deploy-openshift4-powervs-script.tfvars.template
+++ b/deploy/templates/.deploy-openshift4-powervs-script.tfvars.template
@@ -25,6 +25,8 @@ rhel_subscription_password = "__REDHAT_PASSWORD__"
 openshift_install_tarball =  "__OPENSHIFT_INSTALL_TARBALL__"
 openshift_client_tarball = "__OPENSHIFT_CLIENT_TARBALL__"
 
+install_playbook_repo = "__INSTALL_PLAYBOOK_REPO__"
+
 release_image_override = "__OPENSHIFT_IMAGE__"
 
 fips_compliant = "__FIPS_COMPLIANT__"

--- a/vars/setupCommonEnvironmentVariables.groovy
+++ b/vars/setupCommonEnvironmentVariables.groovy
@@ -16,7 +16,12 @@ def call() {
             // Bellow 4 variables are not used. Disabled in template
             env.HELPERNODE_REPO = "https://github.com/RedHatOfficial/ocp4-helpernode"
             env.HELPERNODE_TAG = ""
-            env.INSTALL_PLAYBOOK_REPO = "https://github.com/ocp-power-automation/ocp4-playbooks"
+            if (env.OCP_RELEASE == "4.14") {
+                env.INSTALL_PLAYBOOK_REPO = "https://github.com/Neha-dot-Yadav/ocp4-playbooks"
+            }
+            else {
+                env.INSTALL_PLAYBOOK_REPO = "https://github.com/ocp-power-automation/ocp4-playbooks"
+            }
             env.INSTALL_PLAYBOOK_TAG = ""
             env.CNI_NETWORK_PROVIDER = "OVNKubernetes"
             //Upgrade variables
@@ -153,7 +158,12 @@ def call() {
 
             env.HELPERNODE_REPO = "https://github.com/RedHatOfficial/ocp4-helpernode"
             env.HELPERNODE_TAG = ""
-            env.INSTALL_PLAYBOOK_REPO = "https://github.com/ocp-power-automation/ocp4-playbooks"
+            if (env.OCP_RELEASE == "4.14") {
+                env.INSTALL_PLAYBOOK_REPO = "https://github.com/Neha-dot-Yadav/ocp4-playbooks"
+            }
+            else {
+                env.INSTALL_PLAYBOOK_REPO = "https://github.com/ocp-power-automation/ocp4-playbooks"
+            }
             env.INSTALL_PLAYBOOK_TAG = ""
 
             // Compute Template Variables


### PR DESCRIPTION
This PR changes to install_playbook_repo to a customised one which has the provision to not run the ssh connection test on the workers.

Tested by running _daily-ocp4.14-powervm-p9-min-test_ and _weekly-ocp4.14-powervm-p9-croo_ pipelines.