### PR TITLE
Adjust IPI 4.15 job schedules and disable PowerVS 4.14 UPI jobs

### DIFF
--- a/hack/jjb_template.jinja2
+++ b/hack/jjb_template.jinja2
@@ -3,9 +3,8 @@
     name: {{ JOB_NAME }}
     project-type: pipeline
     triggers:
-      - timed: {% if 'daily-ocp4.16-powervs-script-p9-min' in JOB_NAME %}"0 00 * * 1,3,5 "
-        {% elif 'daily-ocp4.15-powervs-script-p9-min' in JOB_NAME %}"0 00 * * 2 "
-        {% elif 'daily-ocp4.14-powervs-script-p9-min' in JOB_NAME %}"0 00 * * 4 "
+      - timed: {% if 'daily-ocp4.16-powervs-script-p9-min' in JOB_NAME %}"0 06 * * 1,3,5 "
+        {% elif 'daily-ocp4.15-powervs-script-p9-min' in JOB_NAME %}"0 06 * * 2 "
         {% elif 'daily-ocp4.14-powervm-p9-min' in JOB_NAME %}"00 05 * * * "
         {% elif 'daily-ocp4.15-powervm-p9-min' in JOB_NAME %}"00 01 * * * "
         {% elif 'daily-ocp4.16-powervm-p9-min' in JOB_NAME %}"00 00 * * * "
@@ -22,18 +21,17 @@
         {% elif 'weekly-ocp4.16-powervm-p9-vscsi' in JOB_NAME %}"00 09 * * 7 "
         {% elif 'weekly-ocp4.16-powervm-p9-sriov' in JOB_NAME %}"00 16 * * 4 "
 
-        {% elif 'daily-ipi4.15-powervs-frankfurt1' in JOB_NAME %}"0 0,8,16 * * * " 
-        {% elif 'daily-ipi4.15-powervs-frankfurt2' in JOB_NAME %}"0 4,12,20 * * * "
-        {% elif 'daily-ipi4.15-powervs-madrid02' in JOB_NAME %}"0 0,8,16 * * * "
-        {% elif 'daily-ipi4.15-powervs-madrid04' in JOB_NAME %}"0 4,12,20 * * * "
+        {% elif 'daily-ipi4.15-powervs-frankfurt1' in JOB_NAME %}"0 0,8,16 * * * "
+        {% elif 'daily-ipi4.15-powervs-washingtondc06' in JOB_NAME %}"0 0,8,16 * * * "
         {% elif 'daily-ipi4.15-powervs-saopaulo04' in JOB_NAME %}"0 2,10,18 * * * "
-        {% elif 'daily-ipi4.15-powervs-washingtondc06' in JOB_NAME %}"0 2,10,18 * * * "
-        {% elif 'daily-ipi4.15-powervs-washingtondc07' in JOB_NAME %}"0 6,14,22 * * * "        
+        {% elif 'daily-ipi4.15-powervs-madrid02' in JOB_NAME %}"0 2,10,18 * * * "
+        {% elif 'daily-ipi4.15-powervs-frankfurt2' in JOB_NAME %}"0 4,12,20 * * * "
+        {% elif 'daily-ipi4.15-powervs-washingtondc07' in JOB_NAME %}"0 4,12,20 * * * "
+        {% elif 'daily-ipi4.15-powervs-madrid04' in JOB_NAME %}"0 6,14,22 * * * "
 
         {% elif 'mirror-openshift-release' in JOB_NAME %}"@hourly"
         {% elif 'poll-powervc-images' in JOB_NAME %}"@daily"
         {% elif 'poll-powervs-images' in JOB_NAME %}"@daily"
-        {% elif 'daily-jenkins-backup-job' in JOB_NAME %}"@daily"
         {% else %}""
         {% endif %}
     sandbox: true
@@ -47,8 +45,8 @@
           artifact-num-to-keep: 200
       {% elif 'daily-ipi' in JOB_NAME %}
       - build-discarder:
-          num-to-keep: 50
-          artifact-num-to-keep: 50
+          num-to-keep: 30
+          artifact-num-to-keep: 30
       {% else %}
       - build-discarder:
           num-to-keep: 30


### PR DESCRIPTION
- Adjusting ipi jobs schedule's as madrid and frankfurt running concurrently as a results they're conflicting with each other on image pulls apparently.
- Disable 4.14 PowerVS UPI job.
- Reduced the build-discarder num-to-keep to 30