### PR TITLE
Change PowerVS Jenkins jobs agent to docker

### DIFF
--- a/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-madrid02/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-madrid02/Jenkinsfile
@@ -2,8 +2,10 @@
 
 pipeline {
     agent {
-        kubernetes {
-            inheritFrom 'jenkins-agent'
+        docker {
+            image 'quay.io/powercloud/inbound-agent:4.13.3-1.1'
+            args '-v /etc/resolv.conf:/etc/resolv.conf'
+            label 'jump-vpc-x86_64'
         }
     }
     environment {

--- a/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc06/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc06/Jenkinsfile
@@ -2,8 +2,10 @@
 
 pipeline {
     agent {
-        kubernetes {
-            inheritFrom 'jenkins-agent'
+        docker {
+            image 'quay.io/powercloud/inbound-agent:4.13.3-1.1'
+            args '-v /etc/resolv.conf:/etc/resolv.conf'
+            label 'jump-vpc-x86_64'
         }
     }
     environment {

--- a/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc07/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc07/Jenkinsfile
@@ -2,8 +2,10 @@
 
 pipeline {
     agent {
-        kubernetes {
-            inheritFrom 'jenkins-agent'
+        docker {
+            image 'quay.io/powercloud/inbound-agent:4.13.3-1.1'
+            args '-v /etc/resolv.conf:/etc/resolv.conf'
+            label 'jump-vpc-x86_64'
         }
     }
     environment {


### PR DESCRIPTION
As most of the powervs ipi/upi jobs are aborting due to disk pressure on k8s prow-cluster, so moving few jobs to docker agent for the time being.