### PR TITLE
Remove local images after pushing them to registry and change IPI agent.

### DIFF
--- a/jobs/pipelines/powervm/ocp/4.12/weekly-ocp4.12-to-4.13-powervm-p9-min-upgrade/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.12/weekly-ocp4.12-to-4.13-powervm-p9-min-upgrade/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
             steps {
                 script {
                     getArtifacts("mirror-openshift-release", "latest-${OCP_RELEASE}-stable-build.txt")
-                    getArtifacts("mirror-openshift-release", "latest-${UPGRADE_OCP_RELEASE}-build.txt")
+                    getArtifacts("mirror-openshift-release", "latest-${UPGRADE_OCP_RELEASE}-stable-build.txt")
                     getArtifacts("powervm/poll-powervc-images", "cicd-rhcos-${OCP_RELEASE}.latest.txt")
                     getArtifacts("powervm/poll-powervc-images", "cicd-rhel-${REDHAT_RELEASE}.latest.txt")
                 }
@@ -95,16 +95,16 @@ pipeline {
                             env.OCP_RELEASE_TAG = env.OPENSHIFT_IMAGE.split(":")[1].trim()
                         }
                         else {
-                            echo "latest-${OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${OCP_RELEASE}-stable-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         env.UPGRADE_IMAGE  = ""
-                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-build.txt")) {
-                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-build.txt"
+                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-stable-build.txt")) {
+                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-stable-build.txt"
                             env.UPGRADE_IMAGE = env.UPGRADE_IMAGE.trim()
                         }
                         else {
-                            echo "latest-${UPGRADE_OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${UPGRADE_OCP_RELEASE}-stable-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {

--- a/jobs/pipelines/powervm/ocp/4.13/weekly-ocp4.13-powervm-p9-min/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/weekly-ocp4.13-powervm-p9-min/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
                             env.OCP_RELEASE_TAG = env.OPENSHIFT_IMAGE.split(":")[1].trim()
                         }
                         else {
-                            echo "latest-${OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${OCP_RELEASE}-stable-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {

--- a/jobs/pipelines/powervm/ocp/4.13/weekly-ocp4.13-to-4.14-powervm-p9-min-upgrade/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.13/weekly-ocp4.13-to-4.14-powervm-p9-min-upgrade/Jenkinsfile
@@ -89,22 +89,22 @@ pipeline {
                         gbToMb()
                         pullSecret()
                         env.OPENSHIFT_IMAGE = ""
-                        if (fileExists("deploy/artifactory/latest-${OCP_RELEASE}-rc-build.txt")) {
-                            env.OPENSHIFT_IMAGE = readFile "deploy/artifactory/latest-${OCP_RELEASE}-rc-build.txt"
+                        if (fileExists("deploy/artifactory/latest-${OCP_RELEASE}-stable-build.txt")) {
+                            env.OPENSHIFT_IMAGE = readFile "deploy/artifactory/latest-${OCP_RELEASE}-stable-build.txt"
                             env.OPENSHIFT_IMAGE = env.OPENSHIFT_IMAGE.trim()
                             env.OCP_RELEASE_TAG = env.OPENSHIFT_IMAGE.split(":")[1].trim()
                         }
                         else {
-                            echo "latest-${OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${OCP_RELEASE}-stable-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         env.UPGRADE_IMAGE  = ""
-                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-ec-build.txt")) {
-                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-ec-build.txt"
+                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-stable-build.txt")) {
+                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-stable-build.txt"
                             env.UPGRADE_IMAGE = env.UPGRADE_IMAGE.trim()
                         }
                         else {
-                            echo "latest-${UPGRADE_OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${UPGRADE_OCP_RELEASE}-stable-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {

--- a/jobs/pipelines/powervm/ocp/4.14/weekly-ocp4.14-to-4.15-powervm-p9-min-upgrade/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.14/weekly-ocp4.14-to-4.15-powervm-p9-min-upgrade/Jenkinsfile
@@ -89,22 +89,22 @@ pipeline {
                         gbToMb()
                         pullSecret()
                         env.OPENSHIFT_IMAGE = ""
-                        if (fileExists("deploy/artifactory/latest-${OCP_RELEASE}-rc-build.txt")) {
-                            env.OPENSHIFT_IMAGE = readFile "deploy/artifactory/latest-${OCP_RELEASE}-rc-build.txt"
+                        if (fileExists("deploy/artifactory/latest-${OCP_RELEASE}-stable-build.txt")) {
+                            env.OPENSHIFT_IMAGE = readFile "deploy/artifactory/latest-${OCP_RELEASE}-stable-build.txt"
                             env.OPENSHIFT_IMAGE = env.OPENSHIFT_IMAGE.trim()
                             env.OCP_RELEASE_TAG = env.OPENSHIFT_IMAGE.split(":")[1].trim()
                         }
                         else {
-                            echo "latest-${OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${OCP_RELEASE}-stable-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         env.UPGRADE_IMAGE  = ""
-                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-ec-build.txt")) {
-                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-ec-build.txt"
+                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-stable-build.txt")) {
+                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-stable-build.txt"
                             env.UPGRADE_IMAGE = env.UPGRADE_IMAGE.trim()
                         }
                         else {
-                            echo "latest-${UPGRADE_OCP_RELEASE}-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${UPGRADE_OCP_RELEASE}-stable-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {

--- a/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-madrid02/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-madrid02/Jenkinsfile
@@ -2,10 +2,8 @@
 
 pipeline {
     agent {
-        docker {
-            image 'quay.io/powercloud/inbound-agent:4.13.3-1.1'
-            args '-v /etc/resolv.conf:/etc/resolv.conf'
-            label 'jump-vpc-x86_64'
+        kubernetes {
+            inheritFrom 'jenkins-agent'
         }
     }
     environment {

--- a/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc06/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc06/Jenkinsfile
@@ -2,10 +2,8 @@
 
 pipeline {
     agent {
-        docker {
-            image 'quay.io/powercloud/inbound-agent:4.13.3-1.1'
-            args '-v /etc/resolv.conf:/etc/resolv.conf'
-            label 'jump-vpc-x86_64'
+        kubernetes {
+            inheritFrom 'jenkins-agent'
         }
     }
     environment {

--- a/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc07/Jenkinsfile
+++ b/jobs/pipelines/powervs/ipi/4.15/daily-ipi4.15-powervs-washingtondc07/Jenkinsfile
@@ -2,10 +2,8 @@
 
 pipeline {
     agent {
-        docker {
-            image 'quay.io/powercloud/inbound-agent:4.13.3-1.1'
-            args '-v /etc/resolv.conf:/etc/resolv.conf'
-            label 'jump-vpc-x86_64'
+        kubernetes {
+            inheritFrom 'jenkins-agent'
         }
     }
     environment {

--- a/scripts/mirror-images.sh
+++ b/scripts/mirror-images.sh
@@ -6,30 +6,41 @@ compare_time=$(date -d  "1128 hour ago" +%s)
 public_repo=$(./oc get is release-ppc64le -n ocp-ppc64le -o=json | jq -r -c '.status.publicDockerImageRepository')
 target_repo="${DOCKER_REGISTRY}/ocp-ppc64le/release-ppc64le"
 
+#Check if the image tag is availble in the target repository.
+checkImage(){ 
+    curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" "https://na.artifactory.swg-devops.com/artifactory/sys-powercloud-docker-local/ocp-ppc64le/release-ppc64le/${1}/"
+}
+
 echo here is the public repo: $public_repo
 for annotation in $(./oc get is release-ppc64le -n ocp-ppc64le -o=json | jq -c '.spec.tags[]'); do
     _jq() {
-     echo ${annotation} | jq -r ${1}
+     echo ${annotation} | jq -r ${1} 2> /dev/null
     }
 
     creation_time=$(_jq '.annotations."release.openshift.io/creationTimestamp"')
-    if [ "$creation_time" == "null" ]; then
+    if [ "$creation_time" == "null" ] || [ -z "$creation_time" ]; then
        continue
     fi
     creation_timestamp=$(date -d ${creation_time} +%s)
     if [ ${creation_timestamp} -gt ${compare_time} ]; then
         tag=$(_jq '.name')
-        echo $creation_time
-        nerdctl pull ${public_repo}:${tag}
-        nerdctl tag ${public_repo}:${tag} ${target_repo}:${tag}
-        nerdctl push ${target_repo}:${tag}
+        if [ ! $(checkImage ${tag}) == "200" ]; then
+            echo "Image Tag: ${tag} not available in target repository: ${target_repo}:${tag}"
+            nerdctl pull ${public_repo}:${tag}
+            nerdctl tag ${public_repo}:${tag} ${target_repo}:${tag}
+            nerdctl push ${target_repo}:${tag}
+            nerdctl rmi ${public_repo}:${tag} ${target_repo}:${tag} ${target_repo}:${tag}-tmp-single
+        fi
     fi
 done
 
 # Pulling EC builds
 curl https://ppc64le.ocp.releases.ci.openshift.org/api/v1/releasestream/4-dev-preview-ppc64le/latest > build.txt
 ec_build=$(jq ".pullSpec"  build.txt |tr -d '"')
-nerdctl pull $ec_build
 ec_tag=$(jq ".name"  build.txt |tr -d '"')
-nerdctl tag $ec_build ${target_repo}:$ec_tag
-nerdctl push ${target_repo}:$ec_tag
+if [ ! $(checkImage ${ec_tag}) == "200" ]; then
+    nerdctl pull $ec_build
+    nerdctl tag $ec_build ${target_repo}:$ec_tag
+    nerdctl push ${target_repo}:$ec_tag
+    nerdctl rmi $ec_build ${target_repo}:$ec_tag ${target_repo}:$ec_tag-tmp-single
+fi


### PR DESCRIPTION
- Added nerdctl rmi command to clean up local images after pull/push.
- Changed IPI jobs Jenkins agent to Kubernetes agent.
- Added a function to check If image tag available in target repo: if available do nothing, if not, pull from public repo and push it to the target repo.
- Added some fixes for ocp powervc stable upgrade jobs.