### PR TITLE
Updated go version in the PowerVS 4.16 ocp job and the SCG ID for PowerVC 4.16 vscsi job.

### DIFF
--- a/hack/jjb_template.jinja2
+++ b/hack/jjb_template.jinja2
@@ -27,7 +27,7 @@
         {% elif 'daily-ipi4.15-powervs-madrid02' in JOB_NAME %}"0 2,10,18 * * * "
         {% elif 'daily-ipi4.15-powervs-frankfurt2' in JOB_NAME %}"0 4,12,20 * * * "
         {% elif 'daily-ipi4.15-powervs-washingtondc07' in JOB_NAME %}"0 4,12,20 * * * "
-        {% elif 'daily-ipi4.15-powervs-madrid04' in JOB_NAME %}"0 6,14,22 * * * "
+        {% elif 'daily-ipi4.15-powervs-madrid04' in JOB_NAME %}"0 6,14,22 * * 1-5 "
 
         {% elif 'mirror-openshift-release' in JOB_NAME %}"@hourly"
         {% elif 'poll-powervc-images' in JOB_NAME %}"@daily"

--- a/jobs/pipelines/powervm/ocp/4.16/weekly-ocp4.16-powervm-p9-vscsi/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.16/weekly-ocp4.16-powervm-p9-vscsi/Jenkinsfile
@@ -133,7 +133,7 @@ pipeline {
             steps {
                 initializeEnvironment()
                 script {
-                    env.SCG_ID = "9b0d66a9-2339-4e73-97e3-04c844a86ec7"
+                    env.SCG_ID = "6c9e720d-52d6-4426-8af1-6187f18bd36a"
                 }
             }
         }

--- a/jobs/pipelines/powervs/ocp/4.16/daily-ocp4.16-powervs-script-p9-min/Jenkinsfile
+++ b/jobs/pipelines/powervs/ocp/4.16/daily-ocp4.16-powervs-script-p9-min/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         IBM_CLOUD_ZONE = "mon01"
         SERVICE_INSTANCE_ID = "7545067f-dc8c-40d3-be18-13f433d19b62"
 
-        BASTION_IMAGE = "rhel-92"
+        BASTION_IMAGE = "rhel-93"
         RHCOS_IMAGE = "rhcos-416"
         BASTION_IMAGE_FILE = "latest-${BASTION_IMAGE}-rdr-ocp-cicd-montreal01.txt"
         RHCOS_IMAGE_FILE = "latest-${RHCOS_IMAGE}-rdr-ocp-cicd-montreal01.txt"
@@ -30,7 +30,7 @@ pipeline {
 
         //e2e specific variables
         ENABLE_E2E_TEST = "true"
-        GOLANG_TARBALL = "https://golang.org/dl/go1.20.linux-ppc64le.tar.gz"
+        GOLANG_TARBALL = "https://golang.org/dl/go1.22.0.linux-ppc64le.tar.gz"
 
          //Script arguments
         RELEASE_VER="4.16"

--- a/scripts/verification.sh
+++ b/scripts/verification.sh
@@ -15,22 +15,13 @@ ansible-playbook  -i inventory -e @all.yaml playbooks/main.yml
 echo "Setting up environmental variables"
 OC_URL=$(oc whoami --show-server)
 OC_URL=$(echo $OC_URL | cut -d':' -f2 | tr -d [/])
+OC_CONSOLE_URL=$(oc whoami --show-console)
+ver_cli=$(oc version --client | grep -i client | cut -d ' ' -f 3 | cut -d '.' -f1,2)
 export BUSHSLICER_DEFAULT_ENVIRONMENT=ocp4
 export OPENSHIFT_ENV_OCP4_HOSTS=$OC_URL:lb
 export OPENSHIFT_ENV_OCP4_USER_MANAGER_USERS=testuser:testuser
 export OPENSHIFT_ENV_OCP4_ADMIN_CREDS_SPEC=file:///root/openstack-upi/auth/kubeconfig
-export BUSHSLICER_CONFIG='
-global:
-  browser: firefox
-environments:
-  ocp4:
-    admin_creds_spec: /root/openstack-upi/auth/kubeconfig
-    version: "4.12.0"
-    #api_port: 443      # For HA clusters, both 3.x and 4.x
-    #api_port: 6443     # For non-HA 4.x clusters
-    #api_port: 8443     # For non-HA 3.x clusters
-    #web_console_url: https://console-openshift-console.apps.*.openshift.com
-'
+export BUSHSLICER_CONFIG="{'global': {'browser': 'firefox'}, 'environments': {'ocp4': {'admin_creds_spec': '/root/openstack-upi/auth/kubeconfig', 'api_port': '6443', 'web_console_url': '${OC_CONSOLE_URL}', 'version': '${ver_cli}.0'}}}"
 echo $BUSHSLICER_DEFAULT_ENVIRONMENT
 echo $OPENSHIFT_ENV_OCP4_HOSTS
 echo $OPENSHIFT_ENV_OCP4_USER_MANAGER_USERS


### PR DESCRIPTION
- Updated go version to 1.22.0 as the e2e conformance openshift/origin is failing to build openshift-tests binary, it requires go 1.21.0+ version.
- Updated PowerVS Job RHEL version to 9.3.
- Updated 4.16 PowerVC vscsi job sci ID.
- Updated verification tests config.
- Disabling the ipi job on mad04 on weekends.