### PR TITLE
Remove older and unsupported versions from mirror job

### DIFF
--- a/jobs/pipelines/mirror-openshift-release/Jenkinsfile
+++ b/jobs/pipelines/mirror-openshift-release/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
             }
         }
 
-        stage('Prepare Terraform Template') {
+        stage('Download OCP Build info') {
             steps {
                 script {
                     ansiColor('xterm') {
@@ -55,9 +55,6 @@ pipeline {
                     curl https://openshift-release-ppc64le.apps.ci.l2s4.p1.openshiftapps.com/ > builds.raw.txt
                     cat builds.raw.txt | grep -A 2 '<td class="text-monospace"' | grep -v '^--' | awk 'NR%3{printf "%s ",$0;next;}1'|grep -v 'Failed' |sed 's|\\([^/]*/\\)\\{4\\}[^>]*>\\([^>]*\\).*title[^"]*"\\([^"]*\\).*|\\2  \\3|' | sed 's/<\\/a//'| sort -k2 -r |awk -v registry="${DOCKER_REGISTRY}" '{print registry"/ocp-ppc64le/release-ppc64le:"$0}' > all-builds.txt
                     #All Builds
-                    grep '4\\.8\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.8-builds.txt
-                    grep '4\\.9\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.9-builds.txt
-                    grep '4\\.10\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.10-builds.txt
                     grep '4\\.11\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.11-builds.txt
                     grep '4\\.12\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.12-builds.txt
                     grep '4\\.13\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.13-builds.txt
@@ -67,9 +64,6 @@ pipeline {
                     grep '4\\.17\\.[0-9]\\?[0-9]' all-builds.txt  > all-4.17-builds.txt
 
                     #Latest Builds
-                    cat all-4.8-builds.txt|head -n 1|awk '{print $1}'  > latest-4.8-build.txt
-                    cat all-4.9-builds.txt|head -n 1|awk '{print $1}'  > latest-4.9-build.txt
-                    cat all-4.10-builds.txt|head -n 1|awk '{print $1}' > latest-4.10-build.txt
                     cat all-4.11-builds.txt|head -n 1|awk '{print $1}' > latest-4.11-build.txt
                     cat all-4.12-builds.txt|head -n 1|awk '{print $1}' > latest-4.12-build.txt
                     cat all-4.13-builds.txt|head -n 1|awk '{print $1}' > latest-4.13-build.txt
@@ -79,46 +73,34 @@ pipeline {
                     cat all-4.17-builds.txt|head -n 1|awk '{print $1}' > latest-4.17-build.txt
 
                     #All stable Builds
-                    cat all-4.8-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.8-stable-builds.txt
-                    cat all-4.9-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.9-stable-builds.txt
-                    cat all-4.10-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.10-stable-builds.txt
                     cat all-4.11-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.11-stable-builds.txt
                     cat all-4.12-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.12-stable-builds.txt
                     cat all-4.13-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.13-stable-builds.txt
                     cat all-4.14-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.14-stable-builds.txt
                     cat all-4.15-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.15-stable-builds.txt
                     cat all-4.16-builds.txt | grep -v 'nightly\\|-rc\\|-fc\\|-ec' > all-4.16-stable-builds.txt
-                    cat all-4.14-builds.txt | grep '\\-ec' > all-4.14-ec-builds.txt
                     cat all-4.14-builds.txt | grep '\\-rc' > all-4.14-rc-builds.txt
-                    cat all-4.15-builds.txt | grep '\\-ec' > all-4.15-ec-builds.txt
                     cat all-4.15-builds.txt | grep '\\-rc' > all-4.15-rc-builds.txt
-                    cat all-4.16-builds.txt | grep '\\-ec' > all-4.16-ec-builds.txt
                     cat all-4.17-builds.txt | grep '\\-ec' > all-4.17-ec-builds.txt
                     cat all-4.16-builds.txt | grep '\\-rc' > all-4.16-rc-builds.txt
 
 
                     #Latest stable build
-                    cat all-4.8-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.8-stable-build.txt
-                    cat all-4.9-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.9-stable-build.txt
-                    cat all-4.10-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.10-stable-build.txt
                     cat all-4.11-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.11-stable-build.txt
                     cat all-4.12-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.12-stable-build.txt
                     cat all-4.13-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.13-stable-build.txt
                     cat all-4.14-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.14-stable-build.txt
                     cat all-4.15-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.15-stable-build.txt
                     cat all-4.16-stable-builds.txt |head -n 1|awk '{print $1}' > latest-4.16-stable-build.txt
-                    cat all-4.14-ec-builds.txt |head -n 1|awk '{print $1}' > latest-4.14-ec-build.txt
                     cat all-4.14-rc-builds.txt |head -n 1|awk '{print $1}' > latest-4.14-rc-build.txt
                     cat all-4.15-rc-builds.txt |head -n 1|awk '{print $1}' > latest-4.15-rc-build.txt
-                    cat all-4.15-ec-builds.txt |head -n 1|awk '{print $1}' > latest-4.15-ec-build.txt
-                    cat all-4.16-ec-builds.txt |head -n 1|awk '{print $1}' > latest-4.16-ec-build.txt
                     cat all-4.17-ec-builds.txt |head -n 1|awk '{print $1}' > latest-4.17-ec-build.txt
                     cat all-4.16-rc-builds.txt |head -n 1|awk '{print $1}' > latest-4.16-rc-build.txt
                     '''
                     }
                     catch (err)
                     {
-                        echo 'Error ! Template preparation failed !'
+                        echo 'Error ! Download OCP Build info failed !'
                         env.FAILED_STAGE=env.STAGE_NAME
                         throw err
                     }
@@ -128,18 +110,14 @@ pipeline {
     }
     post {
         always {
-            archiveAllArtifacts("builds.raw.txt", "all-builds.txt", "all-4.8-builds.txt","all-4.9-builds.txt",
-                                  "all-4.10-builds.txt","all-4.11-builds.txt", "all-4.12-builds.txt", "all-4.13-builds.txt",
+            archiveAllArtifacts("builds.raw.txt", "all-builds.txt", "all-4.11-builds.txt", "all-4.12-builds.txt", "all-4.13-builds.txt",
                                   "all-4.14-builds.txt", "all-4.15-builds.txt", "all-4.16-builds.txt", "all-4.17-builds.txt",
-                                  "latest-4.8-build.txt", "latest-4.9-build.txt","latest-4.10-build.txt",
                                   "latest-4.11-build.txt","latest-4.12-build.txt", "latest-4.13-build.txt",
                                   "latest-4.14-build.txt", "latest-4.15-build.txt", "latest-4.16-build.txt", "latest-4.17-build.txt",
-                                  "all-4.8-stable-builds.txt", "all-4.9-stable-builds.txt","all-4.10-stable-builds.txt",
                                   "all-4.11-stable-builds.txt","all-4.12-stable-builds.txt","all-4.13-stable-builds.txt", "all-4.14-stable-builds.txt", "all-4.15-stable-builds.txt", "all-4.16-stable-builds.txt",
-                                  "all-4.14-ec-builds.txt", "all-4.14-rc-builds.txt", "all-4.15-ec-builds.txt", "all-4.15-rc-builds.txt", "all-4.16-ec-builds.txt", "all-4.17-ec-builds.txt", "all-4.16-rc-builds.txt",
-                                  "latest-4.8-stable-build.txt", "latest-4.9-stable-build.txt", "latest-4.10-stable-build.txt",
+                                  "all-4.14-rc-builds.txt", "all-4.15-rc-builds.txt", "all-4.17-ec-builds.txt", "all-4.16-rc-builds.txt",
                                   "latest-4.11-stable-build.txt", "latest-4.12-stable-build.txt","latest-4.13-stable-build.txt", "latest-4.14-stable-build.txt", "latest-4.15-stable-build.txt", "latest-4.16-stable-build.txt",
-                                  "latest-4.14-ec-build.txt", "latest-4.14-rc-build.txt", "latest-4.15-rc-build.txt", "latest-4.15-ec-build.txt", "latest-4.16-ec-build.txt", "latest-4.17-ec-build.txt", "latest-4.16-rc-build.txt")
+                                  "latest-4.14-rc-build.txt", "latest-4.15-rc-build.txt", "latest-4.17-ec-build.txt", "latest-4.16-rc-build.txt")
             cleanWs()
         }
     }


### PR DESCRIPTION
mirror job unable to find the older versions and unsupported versions in the `all-builds.txt` file