### PR TITLE
Update SCG ID to use vSCSI storage

### DIFF
--- a/hack/jjb_template.jinja2
+++ b/hack/jjb_template.jinja2
@@ -16,7 +16,7 @@
         {% elif 'weekly-ocp4.18-powervm-p9-min' in JOB_NAME %}"00 16 * * 2 "
         {% elif 'weekly-ocp4.20-powervm-p9-vscsi-multipath' in JOB_NAME %}"00 16 * * 1 "
         {% elif 'weekly-ocp4.19-powervm-p9-verification' in JOB_NAME %}"00 09 * * 6 "
-        {% elif 'weekly-ocp4.20-powervm-p9-vscsi' in JOB_NAME %}"00 09 * * 7 "
+        {% elif 'weekly-ocp4.20-powervm-p9-npiv' in JOB_NAME %}"00 09 * * 7 "
         {% elif 'weekly-ocp4.20-powervm-p9-verification' in JOB_NAME %}"00 09 * * 5 "
         {% elif 'weekly-ocp4.20-powervm-p9-sriov' in JOB_NAME %}"00 16 * * 4 "
 

--- a/jobs/pipelines/mirror-openshift-release/Jenkinsfile
+++ b/jobs/pipelines/mirror-openshift-release/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                     cat all-4.16-builds.txt | grep '\\-rc' > all-4.16-rc-builds.txt
                     cat all-4.17-builds.txt | grep '\\-rc' > all-4.17-rc-builds.txt
                     cat all-4.18-builds.txt | grep '\\-rc' > all-4.18-rc-builds.txt
-                    cat all-4.19-builds.txt | grep '\\-ec' > all-4.19-ec-builds.txt
+                    cat all-4.19-builds.txt | grep '\\-rc' > all-4.19-rc-builds.txt
                     cat all-4.20-builds.txt | grep '\\-ec' > all-4.20-ec-builds.txt
 
 
@@ -89,7 +89,7 @@ pipeline {
                     cat all-4.16-rc-builds.txt |head -n 1|awk '{print $1}' > latest-4.16-rc-build.txt
                     cat all-4.17-rc-builds.txt |head -n 1|awk '{print $1}' > latest-4.17-rc-build.txt
                     cat all-4.18-rc-builds.txt |head -n 1|awk '{print $1}' > latest-4.18-rc-build.txt
-                    cat all-4.19-ec-builds.txt |head -n 1|awk '{print $1}' > latest-4.19-ec-build.txt
+                    cat all-4.19-rc-builds.txt |head -n 1|awk '{print $1}' > latest-4.19-rc-build.txt
                     cat all-4.20-ec-builds.txt |head -n 1|awk '{print $1}' > latest-4.20-ec-build.txt
                     '''
                     }
@@ -110,9 +110,9 @@ pipeline {
                                   "latest-4.11-build.txt","latest-4.12-build.txt", "latest-4.13-build.txt",
                                   "latest-4.14-build.txt", "latest-4.15-build.txt", "latest-4.16-build.txt", "latest-4.17-build.txt", "latest-4.18-build.txt", "latest-4.19-build.txt", "latest-4.20-build.txt",
                                   "all-4.11-stable-builds.txt","all-4.12-stable-builds.txt","all-4.13-stable-builds.txt", "all-4.14-stable-builds.txt", "all-4.15-stable-builds.txt", "all-4.16-stable-builds.txt",  "all-4.17-stable-builds.txt", "all-4.18-stable-builds.txt",
-                                  "all-4.14-rc-builds.txt", "all-4.15-rc-builds.txt", "all-4.16-rc-builds.txt", "all-4.17-rc-builds.txt", "all-4.18-rc-builds.txt",
+                                  "all-4.14-rc-builds.txt", "all-4.15-rc-builds.txt", "all-4.16-rc-builds.txt", "all-4.17-rc-builds.txt", "all-4.18-rc-builds.txt", "all-4.19-rc-builds.txt",
                                   "latest-4.11-stable-build.txt", "latest-4.12-stable-build.txt","latest-4.13-stable-build.txt", "latest-4.14-stable-build.txt", "latest-4.15-stable-build.txt", "latest-4.16-stable-build.txt",  "latest-4.17-stable-build.txt", "latest-4.18-stable-build.txt",
-                                  "latest-4.14-rc-build.txt", "latest-4.15-rc-build.txt", "latest-4.16-rc-build.txt", "latest-4.17-rc-build.txt","latest-4.18-rc-build.txt", "latest-4.19-ec-build.txt", "latest-4.20-ec-build.txt")
+                                  "latest-4.14-rc-build.txt", "latest-4.15-rc-build.txt", "latest-4.16-rc-build.txt", "latest-4.17-rc-build.txt","latest-4.18-rc-build.txt", "latest-4.19-rc-build.txt", "latest-4.20-ec-build.txt")
             cleanWs()
         }
     }

--- a/jobs/pipelines/powervm/ocp/4.18/weekly-ocp4.18-to-4.19-powervm-p9-min-upgrade/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.18/weekly-ocp4.18-to-4.19-powervm-p9-min-upgrade/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
             steps {
                 script {
                     getArtifacts("mirror-openshift-release", "latest-${OCP_RELEASE}-stable-build.txt")
-                    getArtifacts("mirror-openshift-release", "latest-${UPGRADE_OCP_RELEASE}-ec-build.txt")
+                    getArtifacts("mirror-openshift-release", "latest-${UPGRADE_OCP_RELEASE}-rc-build.txt")
                     getArtifacts("powervm/poll-powervc-images", "cicd-rhcos-${OCP_RELEASE}.latest.txt")
                     getArtifacts("powervm/poll-powervc-images", "cicd-rhel-${REDHAT_RELEASE}.latest.txt")
                 }
@@ -102,13 +102,13 @@ pipeline {
                             throw err
                         }
                         env.UPGRADE_IMAGE  = ""
-                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-ec-build.txt")) {
-                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-ec-build.txt"
+                        if (fileExists("deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-rc-build.txt")) {
+                            env.UPGRADE_IMAGE = readFile "deploy/artifactory/latest-${UPGRADE_OCP_RELEASE}-rc-build.txt"
                             env.UPGRADE_IMAGE = env.UPGRADE_IMAGE.trim()
                             env.OCP_UPGRADE_RELEASE_TAG = env.UPGRADE_IMAGE.split(":")[1].trim()
                         }
                         else {
-                            echo "latest-${UPGRADE_OCP_RELEASE}-ec-build.txt file does not exist. Please check mirror-openshift-release job"
+                            echo "latest-${UPGRADE_OCP_RELEASE}-rc-build.txt file does not exist. Please check mirror-openshift-release job"
                             throw err
                         }
                         if (fileExists("deploy/artifactory/cicd-rhcos-${OCP_RELEASE}.latest.txt")) {

--- a/jobs/pipelines/powervm/ocp/4.19/weekly-ocp4.19-powervm-p9-vscsi-multipath/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.19/weekly-ocp4.19-powervm-p9-vscsi-multipath/Jenkinsfile
@@ -135,9 +135,6 @@ pipeline {
         stage('Initialize Environment') {
             steps {
                 initializeEnvironment()
-                script {
-                    env.SCG_ID = "6c9e720d-52d6-4426-8af1-6187f18bd36a"
-                }
             }
         }
         stage('Setup Terraform Plugin') {

--- a/jobs/pipelines/powervm/ocp/4.20/weekly-ocp4.20-powervm-p9-npiv/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.20/weekly-ocp4.20-powervm-p9-npiv/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
             steps {
                 initializeEnvironment()
                 script {
-                    env.SCG_ID = "ba9df88e-d1ba-41ec-a8d9-ec0fd7af7594"
+                    env.SCG_ID = "993a1363-d689-4796-82fb-77ee34e9fa10"
                 }
             }
         }

--- a/jobs/pipelines/powervm/ocp/4.20/weekly-ocp4.20-powervm-p9-vscsi-multipath/Jenkinsfile
+++ b/jobs/pipelines/powervm/ocp/4.20/weekly-ocp4.20-powervm-p9-vscsi-multipath/Jenkinsfile
@@ -136,9 +136,6 @@ pipeline {
         stage('Initialize Environment') {
             steps {
                 initializeEnvironment()
-                script {
-                    env.SCG_ID = "ba9df88e-d1ba-41ec-a8d9-ec0fd7af7594"
-                }
             }
         }
         stage('Setup Terraform Plugin') {

--- a/vars/setupCommonEnvironmentVariables.groovy
+++ b/vars/setupCommonEnvironmentVariables.groovy
@@ -135,7 +135,7 @@ def call() {
                 env.OS_VOLUME_API_VERSION="3"
                 env.OS_NETWORK="vlan1337"
                 env.OS_PRIVATE_NETWORK="vlan1337"
-                env.SCG_ID = "993a1363-d689-4796-82fb-77ee34e9fa10"
+                env.SCG_ID = "ba9df88e-d1ba-41ec-a8d9-ec0fd7af7594"
                 env.VOLUME_STORAGE_TEMPLATE = "ltc12u30_fv72k base template"
                 env.OS_INSECURE = true
                 env.DNS_FORWARDERS = "10.0.10.4; 10.0.10.5"


### PR DESCRIPTION
- All PowerVC jobs now run with vSCSI storage, including Zstream jobs.
- For NPIV, there is a separate weekly job.